### PR TITLE
Fix broken $padUrl in iframe

### DIFF
--- a/views/note/open.php
+++ b/views/note/open.php
@@ -11,7 +11,7 @@ $saveLinkUrl = $note->content->container->createUrl('/notes/note/edit', ['id' =>
 <div class="panel panel-default" id="note_content">
 
     <div class="panel-heading"><?php echo Html::encode($note->title); ?></div>
-    <iframe id="note" src="<?= $padUrl; ?>>" height="400" width="100%"></iframe>
+    <iframe id="note" src="<?= $padUrl; ?>" height="400" width="100%"></iframe>
 
     <?php if (count($editors) > 0) { ?>
         <div class="panel-body">


### PR DESCRIPTION
Just a simple fix. Before this change the note plugin creates two etherpads - `$padId` and `padId>`. When clicking on "Open Note" in humhub note plugin the pad with the ID `$padId` will be opened. But the pad with the ID `$padId>` will be shown in preview and the preview-content will never change from "This is a new pad!".